### PR TITLE
Ili9488init changes

### DIFF
--- a/esphome/components/ili9xxx/ili9xxx_display.cpp
+++ b/esphome/components/ili9xxx/ili9xxx_display.cpp
@@ -60,7 +60,7 @@ void ILI9XXXDisplay::dump_config() {
       ESP_LOGCONFIG(TAG, "  Color mode: 8bit 332 mode");
       break;
   }
-  if (this->is_18bitDisplay) {
+  if (this->is_18bitdisplay) {
     ESP_LOGCONFIG(TAG, "  18-Bit Mode: YES");
   } else {
     ESP_LOGCONFIG(TAG, "  18-Bit Mode: NO");
@@ -131,7 +131,6 @@ void HOT ILI9XXXDisplay::draw_absolute_pixel_internal(int x, int y, Color color)
   if (this->buffer_[pos] != new_color) {
     this->buffer_[pos] = new_color;
     updated = true;
-    
   }
   if (updated) {
     // low and high watermark may speed up drawing from buffer
@@ -171,7 +170,7 @@ void ILI9XXXDisplay::display_() {
     ESP_LOGV(TAG, "Nothing to display");
     return;
   }
-  
+
   set_addr_window_(this->x_low_, this->y_low_, w, h);
 
   ESP_LOGV(TAG,
@@ -188,7 +187,7 @@ void ILI9XXXDisplay::display_() {
       uint32_t sz = std::min(rem, ILI9XXX_TRANSFER_BUFFER_SIZE);
       ESP_LOGVV(TAG, "Send to display(pos:%d, rem:%d, zs:%d)", pos, rem, sz);
       buffer_to_transfer_(pos, sz);
-      if (this->is_18bitDisplay){
+      if (this->is_18bitdisplay) {
         for (uint32_t i = 0; i < sz; ++i) {
           uint16_t color_val = transfer_buffer_[i];
 
@@ -198,15 +197,11 @@ void ILI9XXXDisplay::display_() {
 
           uint8_t pass_buff[3];
 
-          pass_buff[2] = (uint8_t)((red/32.0)*64) << 2;
+          pass_buff[2] = (uint8_t)((red/32.0) * 64) << 2;
           pass_buff[1] = (uint8_t)green << 2;
-          pass_buff[0] = (uint8_t)((blue/32.0)*64) << 2;
+          pass_buff[0] = (uint8_t)((blue/32.0) * 64) << 2;
           
           this->write_array(pass_buff, sizeof(pass_buff));
-          
-          //this->write_byte(blue << 2);
-          //this->write_byte(green << 2);
-          //this->write_byte(red << 2);
 
         }
       } else {
@@ -399,7 +394,7 @@ void ILI9XXXILI9488::initialize() {
   if (this->height_ == 0) {
     this->height_ = 320;
   }
-  this->is_18bitDisplay = true;
+  this->is_18bitdisplay = true;
 }
 //    40_TFT display
 void ILI9XXXST7796::initialize() {

--- a/esphome/components/ili9xxx/ili9xxx_display.cpp
+++ b/esphome/components/ili9xxx/ili9xxx_display.cpp
@@ -60,11 +60,10 @@ void ILI9XXXDisplay::dump_config() {
       ESP_LOGCONFIG(TAG, "  Color mode: 8bit 332 mode");
       break;
   }
-  if (this->is_18bitdisplay) {
+  if (this->is_18bitdisplay_) {
     ESP_LOGCONFIG(TAG, "  18-Bit Mode: YES");
-  } else {
-    ESP_LOGCONFIG(TAG, "  18-Bit Mode: NO");
   }
+
   LOG_PIN("  Reset Pin: ", this->reset_pin_);
   LOG_PIN("  DC Pin: ", this->dc_pin_);
   LOG_PIN("  Busy Pin: ", this->busy_pin_);
@@ -138,8 +137,8 @@ void HOT ILI9XXXDisplay::draw_absolute_pixel_internal(int x, int y, Color color)
     this->y_low_ = (y < this->y_low_) ? y : this->y_low_;
     this->x_high_ = (x > this->x_high_) ? x : this->x_high_;
     this->y_high_ = (y > this->y_high_) ? y : this->y_high_;
-    ESP_LOGVV(TAG, "=>>> pixel (x:%d, y:%d) (xl:%d, xh:%d, yl:%d, yh:%d", x, y, this->x_low_, this->x_high_,
-              this->y_low_, this->y_high_);
+    //ESP_LOGVV(TAG, "=>>> pixel (x:%d, y:%d) (xl:%d, xh:%d, yl:%d, yh:%d", x, y, this->x_low_, this->x_high_,
+    //          this->y_low_, this->y_high_);
   }
 }
 
@@ -185,9 +184,9 @@ void ILI9XXXDisplay::display_() {
 
     while (rem > 0) {
       uint32_t sz = std::min(rem, ILI9XXX_TRANSFER_BUFFER_SIZE);
-      ESP_LOGVV(TAG, "Send to display(pos:%d, rem:%d, zs:%d)", pos, rem, sz);
+      //ESP_LOGVV(TAG, "Send to display(pos:%d, rem:%d, zs:%d)", pos, rem, sz);
       buffer_to_transfer_(pos, sz);
-      if (this->is_18bitdisplay) {
+      if (this->is_18bitdisplay_) {
         for (uint32_t i = 0; i < sz; ++i) {
           uint16_t color_val = transfer_buffer_[i];
 
@@ -197,12 +196,11 @@ void ILI9XXXDisplay::display_() {
 
           uint8_t pass_buff[3];
 
-          pass_buff[2] = (uint8_t)((red/32.0) * 64) << 2;
+          pass_buff[2] = (uint8_t)((red / 32.0) * 64) << 2;
           pass_buff[1] = (uint8_t)green << 2;
-          pass_buff[0] = (uint8_t)((blue/32.0) * 64) << 2;
+          pass_buff[0] = (uint8_t)((blue / 32.0) * 64) << 2;
           
           this->write_array(pass_buff, sizeof(pass_buff));
-
         }
       } else {
         this->write_array16(transfer_buffer_, sz);
@@ -394,7 +392,7 @@ void ILI9XXXILI9488::initialize() {
   if (this->height_ == 0) {
     this->height_ = 320;
   }
-  this->is_18bitdisplay = true;
+  this->is_18bitdisplay_ = true;
 }
 //    40_TFT display
 void ILI9XXXST7796::initialize() {

--- a/esphome/components/ili9xxx/ili9xxx_display.h
+++ b/esphome/components/ili9xxx/ili9xxx_display.h
@@ -85,7 +85,7 @@ class ILI9XXXDisplay : public PollingComponent,
 
   bool prossing_update_ = false;
   bool need_update_ = false;
-  bool is_18bitdisplay = false;
+  bool is_18bitdisplay_ = false;
 };
 
 //-----------   M5Stack display --------------

--- a/esphome/components/ili9xxx/ili9xxx_display.h
+++ b/esphome/components/ili9xxx/ili9xxx_display.h
@@ -18,7 +18,7 @@ enum ILI9XXXColorMode {
 class ILI9XXXDisplay : public PollingComponent,
                        public display::DisplayBuffer,
                        public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW,
-                                             spi::CLOCK_PHASE_LEADING, spi::DATA_RATE_40MHZ> {
+                                             spi::CLOCK_PHASE_LEADING, spi::DATA_RATE_20MHZ> {
  public:
   void set_dc_pin(GPIOPin *dc_pin) { dc_pin_ = dc_pin; }
   float get_setup_priority() const override;
@@ -85,7 +85,7 @@ class ILI9XXXDisplay : public PollingComponent,
 
   bool prossing_update_ = false;
   bool need_update_ = false;
-  bool is_18bitDisplay = false;
+  bool is_18bitdisplay = false;
 };
 
 //-----------   M5Stack display --------------

--- a/esphome/components/ili9xxx/ili9xxx_display.h
+++ b/esphome/components/ili9xxx/ili9xxx_display.h
@@ -18,7 +18,7 @@ enum ILI9XXXColorMode {
 class ILI9XXXDisplay : public PollingComponent,
                        public display::DisplayBuffer,
                        public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW,
-                                             spi::CLOCK_PHASE_LEADING, spi::DATA_RATE_40MHZ> {
+                                             spi::CLOCK_PHASE_LEADING, spi::DATA_RATE_20MHZ> {
  public:
   void set_dc_pin(GPIOPin *dc_pin) { dc_pin_ = dc_pin; }
   float get_setup_priority() const override;
@@ -85,6 +85,7 @@ class ILI9XXXDisplay : public PollingComponent,
 
   bool prossing_update_ = false;
   bool need_update_ = false;
+  bool is_18bitDisplay = false;
 };
 
 //-----------   M5Stack display --------------

--- a/esphome/components/ili9xxx/ili9xxx_display.h
+++ b/esphome/components/ili9xxx/ili9xxx_display.h
@@ -18,7 +18,7 @@ enum ILI9XXXColorMode {
 class ILI9XXXDisplay : public PollingComponent,
                        public display::DisplayBuffer,
                        public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW,
-                                             spi::CLOCK_PHASE_LEADING, spi::DATA_RATE_20MHZ> {
+                                             spi::CLOCK_PHASE_LEADING, spi::DATA_RATE_40MHZ> {
  public:
   void set_dc_pin(GPIOPin *dc_pin) { dc_pin_ = dc_pin; }
   float get_setup_priority() const override;

--- a/esphome/components/ili9xxx/ili9xxx_init.h
+++ b/esphome/components/ili9xxx/ili9xxx_init.h
@@ -114,8 +114,9 @@ static const uint8_t PROGMEM INITCMD_ILI9488[] = {
 
   ILI9XXX_ADJCTL3, 4, 0xA9, 0x51, 0x2C, 0x82,  // Adjust Control 3
 
-  ILI9XXX_MADCTL,  1, 0x48,
-  ILI9XXX_PIXFMT,  1, 0x55,  // Interface Pixel Format = 16bit
+  ILI9XXX_MADCTL,  1, 0x28,
+  //ILI9XXX_PIXFMT,  1, 0x55,  // Interface Pixel Format = 16bit
+  ILI9XXX_PIXFMT, 1, 0x66,   //ILI9488 only supports 18-bit pixel format in 4/3 wire SPI mode
 
 
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- This fixes the ILI9488 display driver so that images appear correctly. The ILI9488 does not support 16-bit color modes when in 3/4 wire SPI mode.  (Even though the datasheet says it can.) -->

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable): N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040


## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
