### PR TITLE
Adding touchscreen functionality for the FT63X6 driver

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -105,6 +105,7 @@ esphome/components/factory_reset/* @anatoly-savchenkov
 esphome/components/fastled_base/* @OttoWinter
 esphome/components/feedback/* @ianchi
 esphome/components/fingerprint_grow/* @OnFreund @loongyh
+esphome/components/ft63x6/* @gpambrozio
 esphome/components/fs3000/* @kahrendt
 esphome/components/gcja5/* @gcormier
 esphome/components/globals/* @esphome/core

--- a/esphome/components/ft63x6/__init__.py
+++ b/esphome/components/ft63x6/__init__.py
@@ -1,0 +1,1 @@
+CODEOWNERS = ["@gpambrozio"]

--- a/esphome/components/ft63x6/ft63x6.cpp
+++ b/esphome/components/ft63x6/ft63x6.cpp
@@ -25,16 +25,13 @@ namespace ft63x6 {
 
 static const char *const TAG = "FT63X6Touchscreen";
 
-void FT63X6TouchscreenStore::gpio_intr(FT63X6TouchscreenStore *store) { store->touch = true; }
 
 void FT63X6Touchscreen::setup() {
   ESP_LOGCONFIG(TAG, "Setting up FT63X6Touchscreen Touchscreen...");
   if (this->interrupt_pin_ != nullptr) {
     this->interrupt_pin_->pin_mode(gpio::FLAG_INPUT | gpio::FLAG_PULLUP);
     this->interrupt_pin_->setup();
-    this->store_.pin = this->interrupt_pin_->to_isr();
-    this->interrupt_pin_->attach_interrupt(FT63X6TouchscreenStore::gpio_intr, &this->store_,
-                                           gpio::INTERRUPT_FALLING_EDGE);
+    this->attach_interrupt_(this->interrupt_pin_pin_, gpio::INTERRUPT_FALLING_EDGE);
   }
 
   if (this->reset_pin_ != nullptr) {
@@ -44,103 +41,30 @@ void FT63X6Touchscreen::setup() {
   this->hard_reset_();
 
   // Get touch resolution
-  this->x_resolution_ = 320;
-  this->y_resolution_ = 480;
+  this->x_raw_max_= 320;
+  this->y_raw_max_= 480;
 }
 
-void FT63X6Touchscreen::loop() {
-  if (this->interrupt_pin_ == nullptr || !this->store_.touch)
-    return;
-  this->store_.touch = false;
-  check_touch_();
-}
 
-void FT63X6Touchscreen::update() {
-  if (this->interrupt_pin_ == nullptr)
-    check_touch_();
-}
-
-void FT63X6Touchscreen::check_touch_() {
+void FT63X6Touchscreen::update_touches() {
   touch_point_.touch_count = read_touch_count_();
 
   if (touch_point_.touch_count == 0) {
-    if (touched_) {
-      touched_ = false;
-      for (auto *listener : this->touch_listeners_)
-        listener->release();
-    }
     return;
   }
 
   touched_ = true;
 
   uint8_t touch_id = read_touch_id_(FT63X6_ADDR_TOUCH1_ID);  // id1 = 0 or 1
-  uint8_t first_touch_id = touch_id;
-  touch_point_.tp[touch_id].status =
-      (touch_point_.tp[touch_id].status == TouchStatusEnum::RELEASE) ? TouchStatusEnum::TOUCH : TouchStatusEnum::REPEAT;
-  touch_point_.tp[touch_id].x = read_touch_coordinate_(FT63X6_ADDR_TOUCH1_X);
-  touch_point_.tp[touch_id].y = read_touch_coordinate_(FT63X6_ADDR_TOUCH1_Y);
+  int16_t x = read_touch_coordinate_(FT63X6_ADDR_TOUCH1_X);
+  int16_t y = read_touch_coordinate_(FT63X6_ADDR_TOUCH1_Y);
+  set_raw_touch_posistion_(touch_id, x, y);
 
   if (touch_point_.touch_count >= 2) {
     touch_id = read_touch_id_(FT63X6_ADDR_TOUCH2_ID);  // id2 = 0 or 1(~id1 & 0x01)
-    touch_point_.tp[touch_id].status = (touch_point_.tp[touch_id].status == TouchStatusEnum::RELEASE)
-                                           ? TouchStatusEnum::TOUCH
-                                           : TouchStatusEnum::REPEAT;
-    touch_point_.tp[touch_id].x = read_touch_coordinate_(FT63X6_ADDR_TOUCH2_X);
-    touch_point_.tp[touch_id].y = read_touch_coordinate_(FT63X6_ADDR_TOUCH2_Y);
-    first_touch_id = 0;
-  } else {
-    touch_point_.tp[~touch_id & 0x01].status = TouchStatusEnum::RELEASE;
-  }
-
-  uint8_t touch_count = std::min<uint8_t>(touch_point_.touch_count, 2);
-  ESP_LOGV(TAG, "Touch count: %d", touch_count);
-
-  uint16_t w = this->display_->get_width();
-  uint16_t h = this->display_->get_height();
-  auto rotation = static_cast<TouchRotation>(this->display_->get_rotation());
-  uint16_t x_resolution, y_resolution;
-    switch (rotation) {
-      case ROTATE_0_DEGREES:
-      case ROTATE_180_DEGREES:
-        x_resolution = this->x_resolution_;
-        y_resolution = this->y_resolution_;
-        break;
-
-      case ROTATE_90_DEGREES:
-      case ROTATE_270_DEGREES:
-        x_resolution = this->y_resolution_;
-        y_resolution = this->x_resolution_;
-        break;
-    }
-
-  for (uint8_t i = first_touch_id; i < (touch_count + first_touch_id); i++) {
-    uint32_t raw_x = touch_point_.tp[i].x * w / x_resolution;
-    uint32_t raw_y = touch_point_.tp[i].y * h / y_resolution;
-
-    TouchPoint tp;
-    switch (rotation) {
-      case ROTATE_0_DEGREES:
-        tp.x = raw_x;
-        tp.y = raw_y;
-        break;
-      case ROTATE_90_DEGREES:
-        tp.x = raw_y;
-        tp.y = h - std::min<uint32_t>(raw_x, h);
-        break;
-      case ROTATE_180_DEGREES:
-        tp.x = w - std::min<uint32_t>(raw_x, w);
-        tp.y = h - std::min<uint32_t>(raw_y, h);
-        break;
-      case ROTATE_270_DEGREES:
-        tp.x = w - std::min<uint32_t>(raw_y, w);
-        tp.y = raw_x;
-        break;
-    }
-
-    tp.id = i;
-    tp.state = (uint8_t) touch_point_.tp[i].status;
-    this->defer([this, tp]() { this->send_touch_(tp); });
+    x = read_touch_coordinate_(FT63X6_ADDR_TOUCH2_X);
+    y = read_touch_coordinate_(FT63X6_ADDR_TOUCH2_Y);
+    set_raw_touch_posistion_(touch_id, x, y);
   }
 }
 

--- a/esphome/components/ft63x6/ft63x6.cpp
+++ b/esphome/components/ft63x6/ft63x6.cpp
@@ -44,7 +44,6 @@ void FT63X6Touchscreen::setup() {
   this->y_raw_max_ = 480;
 }
 
-
 void FT63X6Touchscreen::update_touches() {
   int touch_count = read_touch_count_();
   if (touch_count == 0) {

--- a/esphome/components/ft63x6/ft63x6.cpp
+++ b/esphome/components/ft63x6/ft63x6.cpp
@@ -10,6 +10,9 @@
 
 // Registers
 // Reference: https://focuslcds.com/content/FT6236.pdf
+namespace esphome {
+namespace ft63x6 {
+
 static const uint8_t FT63X6_ADDR_TOUCH_COUNT = 0x02;
 
 static const uint8_t FT63X6_ADDR_TOUCH1_ID = 0x05;
@@ -19,9 +22,6 @@ static const uint8_t FT63X6_ADDR_TOUCH1_Y = 0x05;
 static const uint8_t FT63X6_ADDR_TOUCH2_ID = 0x0B;
 static const uint8_t FT63X6_ADDR_TOUCH2_X = 0x09;
 static const uint8_t FT63X6_ADDR_TOUCH2_Y = 0x0B;
-
-namespace esphome {
-namespace ft63x6 {
 
 static const char *const TAG = "FT63X6Touchscreen";
 
@@ -47,20 +47,17 @@ void FT63X6Touchscreen::setup() {
 
 
 void FT63X6Touchscreen::update_touches() {
-  touch_point_.touch_count = read_touch_count_();
-
-  if (touch_point_.touch_count == 0) {
+  int touch_count = read_touch_count_();
+  if (touch_count == 0) {
     return;
   }
-
-  touched_ = true;
 
   uint8_t touch_id = read_touch_id_(FT63X6_ADDR_TOUCH1_ID);  // id1 = 0 or 1
   int16_t x = read_touch_coordinate_(FT63X6_ADDR_TOUCH1_X);
   int16_t y = read_touch_coordinate_(FT63X6_ADDR_TOUCH1_Y);
   set_raw_touch_posistion_(touch_id, x, y);
 
-  if (touch_point_.touch_count >= 2) {
+  if (touch_count >= 2) {
     touch_id = read_touch_id_(FT63X6_ADDR_TOUCH2_ID);  // id2 = 0 or 1(~id1 & 0x01)
     x = read_touch_coordinate_(FT63X6_ADDR_TOUCH2_X);
     y = read_touch_coordinate_(FT63X6_ADDR_TOUCH2_Y);

--- a/esphome/components/ft63x6/ft63x6.cpp
+++ b/esphome/components/ft63x6/ft63x6.cpp
@@ -25,7 +25,6 @@ static const uint8_t FT63X6_ADDR_TOUCH2_Y = 0x0B;
 
 static const char *const TAG = "FT63X6Touchscreen";
 
-
 void FT63X6Touchscreen::setup() {
   ESP_LOGCONFIG(TAG, "Setting up FT63X6Touchscreen Touchscreen...");
   if (this->interrupt_pin_ != nullptr) {
@@ -41,8 +40,8 @@ void FT63X6Touchscreen::setup() {
   this->hard_reset_();
 
   // Get touch resolution
-  this->x_raw_max_= 320;
-  this->y_raw_max_= 480;
+  this->x_raw_max_ = 320;
+  this->y_raw_max_ = 480;
 }
 
 

--- a/esphome/components/ft63x6/ft63x6.cpp
+++ b/esphome/components/ft63x6/ft63x6.cpp
@@ -1,0 +1,180 @@
+/**************************************************************************/
+/*!
+  Author: Gustavo Ambrozio
+  Based on work by: Atsushi Sasaki (https://github.com/aselectroworks/Arduino-FT6336U)
+*/
+/**************************************************************************/
+
+#include "ft63x6.h"
+#include "esphome/core/log.h"
+
+// Registers
+// Reference: https://focuslcds.com/content/FT6236.pdf
+static const uint8_t FT63X6_ADDR_TOUCH_COUNT = 0x02;
+
+static const uint8_t FT63X6_ADDR_TOUCH1_ID = 0x05;
+static const uint8_t FT63X6_ADDR_TOUCH1_X = 0x03;
+static const uint8_t FT63X6_ADDR_TOUCH1_Y = 0x05;
+
+static const uint8_t FT63X6_ADDR_TOUCH2_ID = 0x0B;
+static const uint8_t FT63X6_ADDR_TOUCH2_X = 0x09;
+static const uint8_t FT63X6_ADDR_TOUCH2_Y = 0x0B;
+
+namespace esphome {
+namespace ft63x6 {
+
+static const char *const TAG = "FT63X6Touchscreen";
+
+void FT63X6TouchscreenStore::gpio_intr(FT63X6TouchscreenStore *store) { store->touch = true; }
+
+void FT63X6Touchscreen::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up FT63X6Touchscreen Touchscreen...");
+  if (this->interrupt_pin_ != nullptr) {
+    this->interrupt_pin_->pin_mode(gpio::FLAG_INPUT | gpio::FLAG_PULLUP);
+    this->interrupt_pin_->setup();
+    this->store_.pin = this->interrupt_pin_->to_isr();
+    this->interrupt_pin_->attach_interrupt(FT63X6TouchscreenStore::gpio_intr, &this->store_,
+                                           gpio::INTERRUPT_FALLING_EDGE);
+  }
+
+  if (this->reset_pin_ != nullptr) {
+    this->reset_pin_->setup();
+  }
+
+  this->hard_reset_();
+
+  // Get touch resolution
+  this->x_resolution_ = 320;
+  this->y_resolution_ = 480;
+}
+
+void FT63X6Touchscreen::loop() {
+  if (this->interrupt_pin_ == nullptr || !this->store_.touch)
+    return;
+  this->store_.touch = false;
+  check_touch_();
+}
+
+void FT63X6Touchscreen::update() {
+  if (this->interrupt_pin_ == nullptr)
+    check_touch_();
+}
+
+void FT63X6Touchscreen::check_touch_() {
+  touch_point_.touch_count = read_touch_count_();
+
+  if (touch_point_.touch_count == 0) {
+    if (touched_) {
+      touched_ = false;
+      for (auto *listener : this->touch_listeners_)
+        listener->release();
+    }
+    return;
+  }
+
+  touched_ = true;
+
+  uint8_t touch_id = read_touch_id_(FT63X6_ADDR_TOUCH1_ID);  // id1 = 0 or 1
+  uint8_t first_touch_id = touch_id;
+  touch_point_.tp[touch_id].status =
+      (touch_point_.tp[touch_id].status == TouchStatusEnum::RELEASE) ? TouchStatusEnum::TOUCH : TouchStatusEnum::REPEAT;
+  touch_point_.tp[touch_id].x = read_touch_coordinate_(FT63X6_ADDR_TOUCH1_X);
+  touch_point_.tp[touch_id].y = read_touch_coordinate_(FT63X6_ADDR_TOUCH1_Y);
+
+  if (touch_point_.touch_count >= 2) {
+    touch_id = read_touch_id_(FT63X6_ADDR_TOUCH2_ID);  // id2 = 0 or 1(~id1 & 0x01)
+    touch_point_.tp[touch_id].status = (touch_point_.tp[touch_id].status == TouchStatusEnum::RELEASE)
+                                           ? TouchStatusEnum::TOUCH
+                                           : TouchStatusEnum::REPEAT;
+    touch_point_.tp[touch_id].x = read_touch_coordinate_(FT63X6_ADDR_TOUCH2_X);
+    touch_point_.tp[touch_id].y = read_touch_coordinate_(FT63X6_ADDR_TOUCH2_Y);
+    first_touch_id = 0;
+  } else {
+    touch_point_.tp[~touch_id & 0x01].status = TouchStatusEnum::RELEASE;
+  }
+
+  uint8_t touch_count = std::min<uint8_t>(touch_point_.touch_count, 2);
+  ESP_LOGV(TAG, "Touch count: %d", touch_count);
+
+  uint16_t w = this->display_->get_width();
+  uint16_t h = this->display_->get_height();
+  auto rotation = static_cast<TouchRotation>(this->display_->get_rotation());
+  uint16_t x_resolution, y_resolution;
+    switch (rotation) {
+      case ROTATE_0_DEGREES:
+      case ROTATE_180_DEGREES:
+        x_resolution = this->x_resolution_;
+        y_resolution = this->y_resolution_;
+        break;
+
+      case ROTATE_90_DEGREES:
+      case ROTATE_270_DEGREES:
+        x_resolution = this->y_resolution_;
+        y_resolution = this->x_resolution_;
+        break;
+    }
+
+  for (uint8_t i = first_touch_id; i < (touch_count + first_touch_id); i++) {
+    uint32_t raw_x = touch_point_.tp[i].x * w / x_resolution;
+    uint32_t raw_y = touch_point_.tp[i].y * h / y_resolution;
+
+    TouchPoint tp;
+    switch (rotation) {
+      case ROTATE_0_DEGREES:
+        tp.x = raw_x;
+        tp.y = raw_y;
+        break;
+      case ROTATE_90_DEGREES:
+        tp.x = raw_y;
+        tp.y = h - std::min<uint32_t>(raw_x, h);
+        break;
+      case ROTATE_180_DEGREES:
+        tp.x = w - std::min<uint32_t>(raw_x, w);
+        tp.y = h - std::min<uint32_t>(raw_y, h);
+        break;
+      case ROTATE_270_DEGREES:
+        tp.x = w - std::min<uint32_t>(raw_y, w);
+        tp.y = raw_x;
+        break;
+    }
+
+    tp.id = i;
+    tp.state = (uint8_t) touch_point_.tp[i].status;
+    this->defer([this, tp]() { this->send_touch_(tp); });
+  }
+}
+
+void FT63X6Touchscreen::hard_reset_() {
+  if (this->reset_pin_ != nullptr) {
+    this->reset_pin_->digital_write(false);
+    delay(10);
+    this->reset_pin_->digital_write(true);
+  }
+}
+
+void FT63X6Touchscreen::dump_config() {
+  ESP_LOGCONFIG(TAG, "FT63X6 Touchscreen:");
+  LOG_I2C_DEVICE(this);
+  LOG_PIN("  Interrupt Pin: ", this->interrupt_pin_);
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+}
+
+uint8_t FT63X6Touchscreen::read_touch_count_() { return read_byte_(FT63X6_ADDR_TOUCH_COUNT); }
+
+// Touch functions
+uint16_t FT63X6Touchscreen::read_touch_coordinate_(uint8_t coordinate) {
+  uint8_t read_buf[2];
+  read_buf[0] = read_byte_(coordinate);
+  read_buf[1] = read_byte_(coordinate + 1);
+  return ((read_buf[0] & 0x0f) << 8) | read_buf[1];
+}
+uint8_t FT63X6Touchscreen::read_touch_id_(uint8_t id_address) { return read_byte_(id_address) >> 4; }
+
+uint8_t FT63X6Touchscreen::read_byte_(uint8_t addr) {
+  uint8_t byte = 0;
+  this->read_byte(addr, &byte);
+  return byte;
+}
+
+}  // namespace ft63x6
+}  // namespace esphome

--- a/esphome/components/ft63x6/ft63x6.h
+++ b/esphome/components/ft63x6/ft63x6.h
@@ -33,7 +33,7 @@ class FT63X6Touchscreen : public Touchscreen, public i2c::I2CDevice {
   InternalGPIOPin *interrupt_pin_{nullptr};
   GPIOPin *reset_pin_{nullptr};
 
-    uint8_t read_touch_count_();
+  uint8_t read_touch_count_();
   uint16_t read_touch_coordinate_(uint8_t coordinate);
   uint8_t read_touch_id_(uint8_t id_address);
 };

--- a/esphome/components/ft63x6/ft63x6.h
+++ b/esphome/components/ft63x6/ft63x6.h
@@ -14,38 +14,12 @@
 namespace esphome {
 namespace ft63x6 {
 
-// Function Specific Type
-enum class TouchStatusEnum : uint8_t {
-  RELEASE = 0,
-  TOUCH = 1,
-  REPEAT = 2,
-};
-
-struct TouchPointType {
-  TouchStatusEnum status;
-  uint16_t x;
-  uint16_t y;
-};
-
-struct FT63X6TouchPoint {
-  uint8_t touch_count;
-  TouchPointType tp[2];
-};
-
-struct FT63X6TouchscreenStore {
-  volatile bool touch;
-  ISRInternalGPIOPin pin;
-
-  static void gpio_intr(FT63X6TouchscreenStore *store);
-};
 
 using namespace touchscreen;
 
-class FT63X6Touchscreen : public Touchscreen, public PollingComponent, public i2c::I2CDevice {
+class FT63X6Touchscreen : public Touchscreen, public i2c::I2CDevice {
  public:
   void setup() override;
-  void loop() override;
-  void update() override;
   void dump_config() override;
 
   void set_interrupt_pin(InternalGPIOPin *pin) { this->interrupt_pin_ = pin; }
@@ -54,20 +28,14 @@ class FT63X6Touchscreen : public Touchscreen, public PollingComponent, public i2
  protected:
   void hard_reset_();
   uint8_t read_byte_(uint8_t addr);
-  void check_touch_();
+  void update_touches() override;
 
   InternalGPIOPin *interrupt_pin_{nullptr};
   GPIOPin *reset_pin_{nullptr};
-  uint16_t x_resolution_;
-  uint16_t y_resolution_;
 
-  uint8_t read_touch_count_();
+    uint8_t read_touch_count_();
   uint16_t read_touch_coordinate_(uint8_t coordinate);
   uint8_t read_touch_id_(uint8_t id_address);
-
-  FT63X6TouchscreenStore store_;
-  FT63X6TouchPoint touch_point_;
-  bool touched_{false};
 };
 
 }  // namespace ft63x6

--- a/esphome/components/ft63x6/ft63x6.h
+++ b/esphome/components/ft63x6/ft63x6.h
@@ -14,7 +14,6 @@
 namespace esphome {
 namespace ft63x6 {
 
-
 using namespace touchscreen;
 
 class FT63X6Touchscreen : public Touchscreen, public i2c::I2CDevice {

--- a/esphome/components/ft63x6/ft63x6.h
+++ b/esphome/components/ft63x6/ft63x6.h
@@ -1,0 +1,74 @@
+/**************************************************************************/
+/*!
+  Author: Gustavo Ambrozio
+  Based on work by: Atsushi Sasaki (https://github.com/aselectroworks/Arduino-FT6336U)
+*/
+/**************************************************************************/
+
+#pragma once
+
+#include "esphome/components/i2c/i2c.h"
+#include "esphome/components/touchscreen/touchscreen.h"
+#include "esphome/core/component.h"
+
+namespace esphome {
+namespace ft63x6 {
+
+// Function Specific Type
+enum class TouchStatusEnum : uint8_t {
+  RELEASE = 0,
+  TOUCH = 1,
+  REPEAT = 2,
+};
+
+struct TouchPointType {
+  TouchStatusEnum status;
+  uint16_t x;
+  uint16_t y;
+};
+
+struct FT63X6TouchPoint {
+  uint8_t touch_count;
+  TouchPointType tp[2];
+};
+
+struct FT63X6TouchscreenStore {
+  volatile bool touch;
+  ISRInternalGPIOPin pin;
+
+  static void gpio_intr(FT63X6TouchscreenStore *store);
+};
+
+using namespace touchscreen;
+
+class FT63X6Touchscreen : public Touchscreen, public PollingComponent, public i2c::I2CDevice {
+ public:
+  void setup() override;
+  void loop() override;
+  void update() override;
+  void dump_config() override;
+
+  void set_interrupt_pin(InternalGPIOPin *pin) { this->interrupt_pin_ = pin; }
+  void set_reset_pin(GPIOPin *pin) { this->reset_pin_ = pin; }
+
+ protected:
+  void hard_reset_();
+  uint8_t read_byte_(uint8_t addr);
+  void check_touch_();
+
+  InternalGPIOPin *interrupt_pin_{nullptr};
+  GPIOPin *reset_pin_{nullptr};
+  uint16_t x_resolution_;
+  uint16_t y_resolution_;
+
+  uint8_t read_touch_count_();
+  uint16_t read_touch_coordinate_(uint8_t coordinate);
+  uint8_t read_touch_id_(uint8_t id_address);
+
+  FT63X6TouchscreenStore store_;
+  FT63X6TouchPoint touch_point_;
+  bool touched_{false};
+};
+
+}  // namespace ft63x6
+}  // namespace esphome

--- a/esphome/components/ft63x6/touchscreen.py
+++ b/esphome/components/ft63x6/touchscreen.py
@@ -30,15 +30,13 @@ CONFIG_SCHEMA = touchscreen.TOUCHSCREEN_SCHEMA.extend(
         }
     )
     .extend(i2c.i2c_device_schema(0x38))
-    .extend(cv.COMPONENT_SCHEMA)
 )
 
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
-    await cg.register_component(var, config)
-    await i2c.register_i2c_device(var, config)
     await touchscreen.register_touchscreen(var, config)
+    await i2c.register_i2c_device(var, config)
 
     if CONF_INTERRUPT_PIN in config:
         interrupt_pin = await cg.gpio_pin_expression(config[CONF_INTERRUPT_PIN])

--- a/esphome/components/ft63x6/touchscreen.py
+++ b/esphome/components/ft63x6/touchscreen.py
@@ -28,8 +28,7 @@ CONFIG_SCHEMA = touchscreen.TOUCHSCREEN_SCHEMA.extend(
             ),
             cv.Optional(CONF_RESET_PIN): pins.gpio_output_pin_schema,
         }
-    )
-    .extend(i2c.i2c_device_schema(0x38))
+    ).extend(i2c.i2c_device_schema(0x38))
 )
 
 

--- a/esphome/components/ft63x6/touchscreen.py
+++ b/esphome/components/ft63x6/touchscreen.py
@@ -1,0 +1,48 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+
+from esphome import pins
+from esphome.components import i2c, touchscreen
+from esphome.const import CONF_ID, CONF_INTERRUPT_PIN, CONF_RESET_PIN
+
+CODEOWNERS = ["@gpambrozio"]
+DEPENDENCIES = ["i2c"]
+
+ft6336u_ns = cg.esphome_ns.namespace("ft63x6")
+FT63X6Touchscreen = ft6336u_ns.class_(
+    "FT63X6Touchscreen",
+    touchscreen.Touchscreen,
+    cg.Component,
+    i2c.I2CDevice,
+)
+
+CONF_FT63X6_ID = "ft63x6_id"
+
+
+CONFIG_SCHEMA = touchscreen.TOUCHSCREEN_SCHEMA.extend(
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(FT63X6Touchscreen),
+            cv.Optional(CONF_INTERRUPT_PIN): cv.All(
+                pins.internal_gpio_input_pin_schema
+            ),
+            cv.Optional(CONF_RESET_PIN): pins.gpio_output_pin_schema,
+        }
+    )
+    .extend(i2c.i2c_device_schema(0x38))
+    .extend(cv.COMPONENT_SCHEMA)
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await i2c.register_i2c_device(var, config)
+    await touchscreen.register_touchscreen(var, config)
+
+    if CONF_INTERRUPT_PIN in config:
+        interrupt_pin = await cg.gpio_pin_expression(config[CONF_INTERRUPT_PIN])
+        cg.add(var.set_interrupt_pin(interrupt_pin))
+    if CONF_RESET_PIN in config:
+        reset_pin = await cg.gpio_pin_expression(config[CONF_RESET_PIN])
+        cg.add(var.set_reset_pin(reset_pin))

--- a/tests/test4.yaml
+++ b/tests/test4.yaml
@@ -709,6 +709,15 @@ touchscreen:
           format: Touch at (%d, %d)
           args: [touch.x, touch.y]
 
+  - platform: ft63x6
+    interrupt_pin: GPIO39
+    reset_pin: GPIO5
+    display: inkplate_display
+    on_touch:
+      - logger.log:
+          format: Touch at (%d, %d)
+          args: [touch.x, touch.y]
+
 i2s_audio:
   i2s_lrclk_pin: GPIO26
   i2s_bclk_pin: GPIO27


### PR DESCRIPTION
# What does this implement/fix?

Touchscreen functionality for the FT63X6 driver (https://focuslcds.com/content/FT6236.pdf)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2352

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
# Might need to adjust display, this works well for the WT32-SC01 display: https://www.seeedstudio.com/ESP32-Development-board-WT32-SC01-p-4735.html
esphome:

esp32:
  board: m5stack-core2
  framework:
    type: arduino

external_components:
  - source: github://gpambrozio/esphome@nvds-touchscreen-optdisp-FT6336U
    components: [ ft63x6 ]

i2c:
  sda: 18
  scl: 19
  scan: false

globals:
  - id: calibration_x
    type: int
    restore_value: no
    initial_value: '0'
  - id: calibration_y
    type: int
    restore_value: no
    initial_value: '0'

font:
  - file: "gfonts://Roboto"
    id: roboto
    size: 20

color:
  - id: my_blue
    blue: 100%

output:
  - platform: ledc
    pin: GPIO23
    id: screen_led

light:
  - platform: monochromatic
    output: screen_led
    id: backlight
    default_transition_length: 0.5s
    name: 'Backlight'
    restore_mode: ALWAYS_ON

display:
  - platform: ili9xxx
    model: ST7796
    cs_pin: GPIO15
    dc_pin: GPIO21
    reset_pin: GPIO22
    rotation: 90
    pages:
      - id: calibration_page
        lambda: |-
          it.line(id(calibration_x) - 10, id(calibration_y), id(calibration_x) + 10, id(calibration_y), id(my_blue));
          it.line(id(calibration_x), id(calibration_y) - 10, id(calibration_x), id(calibration_y) + 10, id(my_blue));
          it.printf(it.get_width() / 2, it.get_height() / 2, id(roboto), TextAlign::CENTER, "%d x %d", id(calibration_x), id(calibration_y));

touchscreen:
  - platform: ft63x6
    on_touch:
      - logger.log:
          format: Touch at (%d, %d)
          args: [touch.x, touch.y]
      - globals.set:
          id: calibration_x
          value: !lambda 'return touch.x;'
      - globals.set:
          id: calibration_y
          value: !lambda 'return touch.y;'

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
