### PR TITLE
remove issue of component setup failure.

### DIFF
--- a/esphome/components/espnow/espnow.cpp
+++ b/esphome/components/espnow/espnow.cpp
@@ -463,6 +463,13 @@ void ESPNowComponent::handle_internal_sent(ESPNowPacket packet, bool status) {
 }
 
 bool ESPNowComponent::send(ESPNowPacket packet) {
+#ifdef USE_WIFI
+  if (!this->can_proceed()) {
+    ESP_LOGW(TAG, "Network not ready, declining message send.");
+    return false;
+  }
+#endif
+
   if (packet.peer == this->own_peer_address_) {
     ESP_LOGE(TAG, "Tried to peer your self.");
   } else if (!this->is_ready()) {


### PR DESCRIPTION
Alright, a lot bit of troubleshooting later if found it the issue why the component was failing 🎉

The issue:
The ESP (with my config) wanted to send espnow messages before the espnow (and with that wifi) setup was ready.
This led to a failure of the component.

The following addition of code fixes it for me.

```cpp
bool ESPNowComponent::send(ESPNowPacket packet) {
#ifdef USE_WIFI
  // If the network is not ready, decline sending the message.
  if (!this->can_proceed()) {
    ESP_LOGW(TAG, "Network not ready, declining message send.");
    return false;
  }
#endif
```

Feel free to merge or do your own version :)

But I'm super happy I got it working on my setup!

Thanks for the great integration! Right what I need haha!!